### PR TITLE
fix(docker): apk upgrade to patch CVE-2026-28390 (openssl HIGH)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -32,7 +32,13 @@ RUN CGO_ENABLED=0 GOOS=$TARGETOS GOARCH=$TARGETARCH go build \
 # Stage 3: Final image
 FROM alpine:3.21 AS production
 LABEL org.opencontainers.image.source="https://github.com/Cepat-Kilat-Teknologi/genieacs-relay"
-RUN apk add --no-cache tzdata ca-certificates \
+# Force package upgrade to pick up the latest patched security packages. The alpine:3.21
+# base image ships a snapshot at tag time, so CVEs fixed AFTER the tag's mint date (e.g.
+# CVE-2026-28390 in libcrypto3/libssl3, fixed in 3.3.7-r0 while base still has 3.3.6-r0)
+# require an explicit `apk upgrade` against the live 3.21 repo. This keeps us on the
+# alpine 3.21 track without chasing minor base bumps every time a new CVE lands.
+RUN apk update && apk upgrade --no-cache \
+    && apk add --no-cache tzdata ca-certificates \
     && cp /usr/share/zoneinfo/Asia/Jakarta /etc/localtime \
     && echo "Asia/Jakarta" > /etc/timezone \
     && apk del tzdata \


### PR DESCRIPTION
## Summary

Post-v2.0.0 merge, Trivy scan on the \`edge\` image flagged **2 HIGH** vulnerabilities:

| Package | Installed | Fixed | CVE |
|---|---|---|---|
| libcrypto3 | 3.3.6-r0 | 3.3.7-r0 | CVE-2026-28390 |
| libssl3 | 3.3.6-r0 | 3.3.7-r0 | CVE-2026-28390 |

**CVE-2026-28390**: openssl DoS via NULL pointer dereference in CMS.

The fix is available in alpine 3.21's live package repo but the \`alpine:3.21\`
base image tag is a point-in-time snapshot and still carries 3.3.6-r0. Added
\`apk update && apk upgrade --no-cache\` as the first step of the production
stage so every rebuild picks up the latest patched packages from the 3.21 repo
without needing to chase base image minor bumps.

## Verification

Rebuilt image locally with \`--no-cache\` and rescanned:

\`\`\`
Report Summary
┌────────────────────────────────────────────┬──────────┬─────────────────┬─────────┐
│                   Target                   │   Type   │ Vulnerabilities │ Secrets │
├────────────────────────────────────────────┼──────────┼─────────────────┼─────────┤
│ genieacs-relay:local-scan2 (alpine 3.21.6) │  alpine  │        0        │    -    │
│ app/main                                   │ gobinary │        0        │    -    │
└────────────────────────────────────────────┴──────────┴─────────────────┴─────────┘
\`\`\`

(Same Trivy flags as CI: \`--severity CRITICAL,HIGH --ignore-unfixed\`)

## Test plan

- [x] Local Trivy rescan returns 0 CRITICAL/HIGH
- [ ] CI Trivy step passes on this PR
- [ ] Post-merge main push CI goes green