### PR TITLE
docs(examples): update pinned versions to v2.0.0

### DIFF
--- a/examples/argocd/application-production.yaml
+++ b/examples/argocd/application-production.yaml
@@ -36,7 +36,7 @@ spec:
         - name: replicaCount
           value: "3"
         - name: image.tag
-          value: "1.0.0"  # Pin to specific version
+          value: "2.0.0"  # Pin to specific version
         - name: config.genieacsBaseUrl
           value: "http://genieacs-nbi.genieacs-prod:7557"
         - name: config.nbiAuth.enabled

--- a/examples/docker/.env.example
+++ b/examples/docker/.env.example
@@ -2,6 +2,14 @@
 # Copy this file to .env and configure your settings
 
 # ===================
+# Image Tag
+# ===================
+# Pin to a specific version tag (recommended for production).
+# Leave commented/unset to fall back to :latest.
+# Available tags: 2.0.0, 2.0, 2, latest, edge (built from main), <git-sha>
+RELAY_VERSION=2.0.0
+
+# ===================
 # Server Configuration
 # ===================
 SERVER_ADDR=:8080

--- a/examples/docker/docker-compose.yml
+++ b/examples/docker/docker-compose.yml
@@ -1,6 +1,6 @@
 services:
   api:
-    # Set RELAY_VERSION in .env or override: RELAY_VERSION=1.2.0 docker compose up
+    # Set RELAY_VERSION in .env or override: RELAY_VERSION=2.0.0 docker compose up
     # Alternative registry: ghcr.io/cepat-kilat-teknologi/genieacs-relay
     image: cepatkilatteknologi/genieacs-relay:${RELAY_VERSION:-latest}
     container_name: genieacs-relay

--- a/examples/helm/genieacs-relay/Chart.yaml
+++ b/examples/helm/genieacs-relay/Chart.yaml
@@ -5,8 +5,8 @@ apiVersion: v2                    # Helm 3 uses apiVersion v2
 name: genieacs-relay              # Chart name (must match folder name)
 description: A lightweight relay service for managing TR-069 devices via GenieACS
 type: application                 # application or library
-version: 0.1.0                    # CHART version (not app), follows SemVer
-appVersion: "latest"              # Application version being deployed
+version: 0.2.0                    # CHART version (not app), follows SemVer
+appVersion: "2.0.0"               # Application version being deployed (genieacs-relay semver)
 
 # Maintainer information
 maintainers:


### PR DESCRIPTION
## Summary

Post-release cleanup. Updates stale version references across deployment examples to match the just-released **v2.0.0**.

## Changes

| File | Change |
|---|---|
| \`examples/helm/genieacs-relay/Chart.yaml\` | \`appVersion: \"latest\"\` → \`\"2.0.0\"\`, chart version \`0.1.0\` → \`0.2.0\` |
| \`examples/argocd/application-production.yaml\` | \`image.tag\` pin \`\"1.0.0\"\` → \`\"2.0.0\"\` |
| \`examples/docker/docker-compose.yml\` | Inline comment \`RELAY_VERSION=1.2.0\` → \`2.0.0\` |
| \`examples/docker/.env.example\` | New **Image Tag** section with \`RELAY_VERSION=2.0.0\` + list of available tags (\`2.0.0\`, \`2.0\`, \`2\`, \`latest\`, \`edge\`, \`<git-sha>\`) |

## Not Touched (deliberately)

- \`examples/kubernetes/deployment.yaml\` uses \`:latest\` — caller overrides via kustomize
- \`examples/argocd/application-image-updater.yaml\` has \`1.0.0\` only in a regex example comment
- \`examples/systemd/*\` — no image tag (installs from apt/binary release)

## Test plan

- [x] Version scan on \`examples/\` returns only intentional references
- [x] Helm chart version bumped per convention (any Chart.yaml change = version bump)
- [ ] CI green (lint+test+vulncheck only; build-push skipped on PR)